### PR TITLE
replace timeline concept with generic updates&ordering

### DIFF
--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -110,8 +110,9 @@ Consider the DAG from the previous chapter. If transaction `C` and  `D` where to
 This would create an inconsistency in the network. To fix this the following rules MUST be taken into account:
 
 * If the payloads are equal, mark both transactions as processed and apply one of the payloads.
-* If the payloads are not equal, apply the payload with the highest *iat*.
-* Else apply the payload with the highest hash.
+* If the payloads are not equal, merge payload according to rules for the specific payload.
+
+The last rule requires the payload to be immutable or conform to its contents MUST be composed of [conflict-free replicated data types](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type)  
 
 ### 3.5. Processing the DAG
 

--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -110,9 +110,9 @@ Consider the DAG from the previous chapter. If transaction `C` and  `D` where to
 This would create an inconsistency in the network. To fix this the following rules MUST be taken into account:
 
 * If the payloads are equal, mark both transactions as processed and apply one of the payloads.
-* If the payloads are not equal, merge payload according to rules for the specific payload.
+* If the payloads are not equal, create a representation that is a merger of the payloads according to rules for the specific payload.
 
-The last rule requires the payload to be immutable or conform to its contents MUST be composed of [conflict-free replicated data types](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type)  
+The last rule requires the payload to be immutable or conform to its contents MUST be composed of [conflict-free replicated data types](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type)
 
 ### 3.5. Processing the DAG
 

--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -112,7 +112,7 @@ This would create an inconsistency in the network. To fix this the following rul
 * If the payloads are equal, process as normal.
 * If the payloads are not equal, create a representation that is a merger of the payloads according to rules for the specific payload.
 
-The last rule requires the payload to be immutable or conform to its contents MUST be composed of [conflict-free replicated data types](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type)
+The last rule requires the payload to be immutable, so a merger is irrelevant. When updates are required, its contents MUST be composed of [conflict-free replicated data types](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type)
 
 ### 3.5. Processing the DAG
 

--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -109,7 +109,7 @@ Parallel updates of the same application data, in the form of branches, MUST be 
 Consider the DAG from the previous chapter. If transaction `C` and  `D` where to update the same application data, nodes could process the transaction in a different order.
 This would create an inconsistency in the network. To fix this the following rules MUST be taken into account:
 
-* If the payloads are equal, mark both transactions as processed and apply one of the payloads.
+* If the payloads are equal, process as normal.
 * If the payloads are not equal, create a representation that is a merger of the payloads according to rules for the specific payload.
 
 The last rule requires the payload to be immutable or conform to its contents MUST be composed of [conflict-free replicated data types](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type)


### PR DESCRIPTION
Closes #30

The choice for parallel updates is determined by information of the transaction compared to application data and previous transactions.

The proposed changes should be checked with application logic currently in the master branch of the node. 