### PR TITLE
changes to RFCs when ordering is required for KID resolution

### DIFF
--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -43,7 +43,7 @@ Other terminology comes from the [Nuts Start Architecture](rfc001-nuts-start-arc
 
 Transactions MUST be encoded as [RFC7515 JSON Web Signature](https://tools.ietf.org/html/rfc7515). It MUST be serialized in compact \([RFC7515 section 7.1](https://tools.ietf.org/html/rfc7515#section-7.1)\) serialization form.
 
-### 3.1. JWS implementation
+### 3.1 JWS implementation
 
 In addition to required header parameters as specified in RFC7515 the following requirements apply:
 
@@ -71,17 +71,17 @@ The contents then MAY be stored next to or apart from the transaction itself \(b
 
 There SHOULD be only 1 signature on the JWS. If there are multiple signatures all signatures except the first one MUST be ignored.
 
-### 3.2. Transaction Reference
+### 3.2 Transaction Reference
 
 The transaction reference uniquely identifies a transaction and is used to refer to it. It MUST be calculated by taking the bytes of the JWS EXACTLY as received and hashing it using SHA-256.
 
 When serializing a reference to string form it MUST be hexadecimal encoded and SHOULD be lowercase, e.g.: `386b20eeae8120f1cd68c354f7114f43149f5a7448103372995302e3b379632a`
 
-### 3.3. Ordering, branching and merging
+### 3.3 Ordering, branching and merging
 
 Transactions MUST form a rooted DAG \(Directed Acyclic Graph\) by referring to the previous transaction. This MAY be used to establish _casual ordering_, e.g. registration of a care organization as child object of a vendor. A new transaction MUST be appended to the end of the DAG by referring to the last transaction of the DAG \(_head_\) by including its reference in the **prevs** field.
 
-All transactions referred to by `prev` MUST be present, since failing to do so would corrupt the DAG.
+All transactions referred to by `prevs` MUST be present, since failing to do so would corrupt the DAG.
 
 As the name implies the DAG MUST be acyclic, transactions that introduce a cycle are invalid MUST be ignored. ANY following transaction that refers to the invalid transaction \(direct or indirect\) MUST be ignored as well.
 
@@ -103,7 +103,7 @@ The following orders are invalid:
 * `A -> B -> D -> F -> C -> E` \(merger processed before all previous were processed\)
 * `A -> B -> D -> E -> C -> F` \(branch C is processed out-of-order\)
 
-### 3.4. Updates & Ordering
+### 3.4 Updates & Ordering
 
 Since transactions are immutable, the only way to update the application data they contain is by creating a new transaction. All updates are considered as full updates, partial updates are not supported. Parallel updates of the same application data, in the form of branches, MUST be processed the same way by all nodes.
 
@@ -114,7 +114,7 @@ Consider the DAG from the previous chapter. If transaction `C` and `D` where to 
 
 When updates are required for a type of transaction content, it MUST be composed of [conflict-free replicated data types](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type)
 
-### 3.5. Processing the DAG
+### 3.5 Processing the DAG
 
 Processing the DAG can be seen as planning tasks required for construction: some tasks can happen in parallel \(laying floors and installing electricity\), some tasks must happen sequentially \(foundation must be poured before building the walls\). This is the same for transactions on the DAG: transactions on a branch MUST be processed sequentially but processing order of parallel branches is unspecified, and before processing a merging transaction all **prevs** \(branches\) must have been processed.
 
@@ -136,11 +136,21 @@ until queue empty; take transaction from queue
     process transaction
 ```
 
-### 3.6. Signature and transaction content verification
+### 3.6 Signature verification
 
-Before interpreting a transaction's content the JWS' signature MUST be validated. When **kid** is used to specify the signing key and the system knows additional usage restrictions \(e.g. the key is valid from X to Y, to be checked against **sigt**\), the system MUST assert the usage is compliant.
+Before interpreting a transaction's content the JWS' signature MUST be validated. Almost all transactions will use the **kid** to identify the key used to sign the transaction.
+Resolving the **kid** based on the signature timestamp (**sigt**) can cause problems and even adds attack vectors.
+The main reason behind this, is that the signature time doesn't set the order of transactions.
+Transaction B can be signed with a key introduced in transaction A. Transaction B depends on A, this dependency can't be solved with the signature time.
+This dependency can be solved by simply referring to the transaction that introduced the **kid**.
+If a ``kid`` is present in the JWS, the `prevs` MUST contain a transaction reference of which the transaction content includes the key entry with the **kid** as identifier.
+If the resolved transaction contents is not the latest version, this may indicate a broken installation or a stolen private key.
 
-Furthermore, since the transaction content is detached from the transaction itself and referred to by hash, the transaction content MUST be hashed and compared to the hash specified in the transaction, to assert that the retrieved transaction content is actually the expected transaction content.
+> **_NOTE:_**  It would be solvable with a central notary or voting scheme that determines the transaction order. This would make the system more complex.  
+
+### 3.7 Transaction content verification
+
+Since the transaction content is detached from the transaction itself and referred to by hash, the transaction content MUST be hashed and compared to the hash specified in the transaction, to assert that the retrieved transaction content is actually the expected transaction content.
 
 ## 4. Example
 

--- a/rfc/rfc006-distributed-registry.md
+++ b/rfc/rfc006-distributed-registry.md
@@ -409,7 +409,7 @@ Since the information is self-proclaimed and not authenticated or verified in an
 
 §3.4 of [RFC004](rfc004-verifiable-transactional-graph.md) requires each payload type to describe how conflicts are resolved when parallel transactions are encountered. A DID Document is not a CRDT, but its contents are. The paragraphs below describe how each of the elements should be treated in case of a conflict. First we describe the mechanism of detecting and resolving conflicts. DID Documents do not refer to their previous version in any way. The transactions described in [RFC004](rfc004-verifiable-transactional-graph.md) do refer to previous transactions. This system can be used to detect conflicts and to resolve them. For DID Documents additional transactional requirements are added:
 
-* Updates to DID Documents MUST refer in their transaction to the transaction of the previous version. They SHOULD also refer to the latest transactions as described by [RFC005](rfc005-distributed-network-using-grpc.md).
+* Updates to DID Documents MUST refer in their transaction to the transaction of the previous version (see [RFC004](rfc004-verifiable-transactional-graph.md#36-signature-verification)). They SHOULD also refer to the latest transactions as described by [RFC005](rfc005-distributed-network-using-grpc.md).
 * In case of a conflict, the conflict can be resolved with an additional transaction referring to the all the conflicting transactions.
 
 ## 5.1 Conflict detection

--- a/rfc/rfc011-verifiable-credential.md
+++ b/rfc/rfc011-verifiable-credential.md
@@ -100,7 +100,12 @@ VC identifiers MUST be constructed as `DID#id` where `id` is unique for the give
 
 A VC MUST have an active issuer at the time of usage. Usage includes using the VC to generate a VP or sending it along in an OAuth flow. If the issuer is deactivated at the time of usage, the VC MUST be regarded as invalid.
 
-### 3.6 VC Example
+### 3.6 Transaction requirements
+
+If a VC issuer is a Nuts DID Subject and the VC is published via a transaction according to [RFC004](rfc004-verifiable-transactional-graph.md) and [RFC005](rfc005-distributed-network-using-grpc.md) then the transaction MUST refer to the correct transaction as specified by [RFC004](rfc004-verifiable-transactional-graph.md#36-signature-verification).
+This ensures the correct ordering of transactions.
+
+### 3.7 VC Example
 
 Below is an example of a credential. **Issuer** and **Subject** are the same in the example. This specification neither requires nor prevents this.
 


### PR DESCRIPTION
This PR changes the `kid` resolution from using `sigt` to using transaction ordering.

In the nuts-node code, the change would be to resolve a DID Document using the hash in the query metadata instead of the timestamp.

Introduction in the code has to be done in 2 steps (or a dev network reset):

- add additional TX refs to `prevs` when publishing
- after a while change resolving of new TXs (after a certain epoch) to use the new resolving.