### PR TITLE
made evidence field optional

### DIFF
--- a/rfc/rfc014-authorization-credential.md
+++ b/rfc/rfc014-authorization-credential.md
@@ -79,7 +79,7 @@ The `credentialSubject` field contains the following:
 
 ### 3.2.1 Required fields
 
-The `id`, `legalBase` and `purposeOfUse` fields MUST be filled. Within the `legalBase` object, `consentType` MUST either be `implied` or `explicit`. When `explicit`, the `evidence` and `subject` fields MUST be filled.
+The `id`, `legalBase` and `purposeOfUse` fields MUST be filled. Within the `legalBase` object, `consentType` MUST either be `implied` or `explicit`. When `explicit`, the `subject` field MUST be filled.
 
 ### 3.2.2 Scoping
 
@@ -87,7 +87,9 @@ The `id` field MUST contain the DID of the actor. The `subject` field MAY contai
 
 ### 3.2.3 Legal base
 
-The patient consent can be either implied or explicit. When it's implied, this should be reflected by the `purposeOfUse`. A Bolt MUST therefore also describe if it is covered by explicit or implied consent. When the credential is given in the context of explicit consent, the `legalBase.evidence` MUST be filled. It MUST contain a value for the `path` and `type` fields. The `path` is a relative path to the service data endpoint and the `type` contains the media type as specified by [RFC6838](https://datatracker.ietf.org/doc/html/rfc6838). The evidence resource MUST be accessible with an access token that was created with the corresponding credential.
+The patient consent can be either implied or explicit. When it's implied, this should be reflected by the `purposeOfUse`. A Bolt MUST therefore also describe if it is covered by explicit or implied consent. 
+When `legalBase.evidence` is filled, it MUST contain a value for the `path` and `type` fields. The `path` is a relative path to the service data endpoint and the `type` contains the media type as specified by [RFC6838](https://datatracker.ietf.org/doc/html/rfc6838). 
+The evidence resource MUST be accessible with an access token that was created with the corresponding credential.
 
 ### 3.2.4 Resources
 


### PR DESCRIPTION
closes #143 

`credentialSubject.evidence` is no longer mandatory.

After merge:

- [ ] change spec and validations in nuts-node
- [ ] after change, notify #development on slack