### PR TITLE
RFC004: Private transactions

### DIFF
--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -163,36 +163,29 @@ Private transactions MUST be added to the DAG like non-private transactions.
 The recipients MUST be specified as array that contains the node DIDs of the recipients, encrypted separately for each recipient.
 To construct the data to be encrypted, the plaintext recipients MUST be joined by a newline (`\n`)
 
-Given 2 recipients `did:nuts:recipient-A` and `did:nuts:recipient-B`.
+The recipient list MUST be encrypted for each recipient and the ciphertext specified as array as `pal` header in the JWS.
+
+Given 2 recipients `did:nuts:recipient-A` and `did:nuts:recipient-B`:
 
 ```
 encoded_recipients = join("did:nuts:recipient-A", "did:nuts:recipient-B", "\\n")
 
-to = []
+pal = []
 
 for each recipient
   encrypted_recipients = ecies_encrypt(encoded_recipients, recipient.encryption_public_key)
-  to = append(to, encrypted_recipients)
+  pal = append(to, encrypted_recipients)
 
-transaction.to = to
+transaction.pal = pal
 ```
 
-The recipient list MUST be encrypted for each recipient and specified as `to` header in the JWS. 
+To decrypt the header, the process above is applied in reverse. If one of the decrypted values match the local node's DID,
+it indicates the local node is (one of) the intended recipient, and it SHOULD try to retrieve the contents.
 
-The recipients list MUST be encrypted with a public encryption key (`keyAgreement` key in DID documents) of each recipient. 
+The encryption key to be used MUST be one of the elliptic curve public encryption keys (`keyAgreement` key in DID documents) of the recipient.
+For encryption of the `pal` header the ECIES encryption algorithm MUST be used.
 
-
-Given the recipients `["did:nuts:recipient-A", "did:nuts:recipient-B"]`
-
-When receiving a transaction containing a `to` header, the receiver then try to decrypt it with its encryption keys.
-If it can be decrypted and the decrypted `to` header matches its own address, the system is the intended recipient and the content can be retrieved.
-
-For encryption of the `to` header the ECIES encryption algorithm MUST be used.
-
-Transport implementations serving transaction contents MUST take care to properly authenticate the requester (of transaction content),
-to avoid leaking the private transaction content to attackers.
-
-See appendix A on the reasoning behind encrypting the `to` header.
+See appendix A on the reasoning behind encrypting the `pal` header.
 
 ## 4. Example
 

--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -176,6 +176,15 @@ eyJhbGciOiJFUzI1NiIsImN0eSI6ImZvby9iYXIiLCJjcml0IjpbInNpZ3QiLCJ2ZXIiLCJwcmV2cyIs
 
 ## Appendix A: Correlation Attacks on Private Transactions
 
-Because relating multiple private transactions, deriving information from their context and metadata, like the creator of the transaction),
+When multiple encrypted documents, intended to be anonymous, contain (encrypted or not) data that is the same for every encrypted document,
+they could be related to each other, deriving information from their context. E.g., sender, time of sending, etc.
+In the context of Nuts: a care organization might issue multiple `NutsAuthorizationCredential`s (meant for giving access to EHR records) at once, to a set of care organizations.
+If the recipients are publicly readable, this gives knowledge of the name, physical location and care type of the organizations that have access.
+Given enough public knowledge and/or information from other contexts, one could ultimately pinpoint the set of issues VCs to a person (e.g. a relative or a celebrity).
 
-The used encryption algorithm must also ensure a different ciphertext is produced every time the address is encrypted, even when the same encryption key is used.
+To mitigate this attack, given a plaintext and encryption key, every subsequent encryption operation (with the same plaintext and key) must yield a new, random ciphertext.
+
+Still, this does not make correlation attacks impossible, just harder.
+E.g.: in small networks, the number of care organizations might be so small, that one could guess the receiving organization with relatively large accuracy.
+Especially when they are issued (and re-issued after they expire) by an automated process.
+This problem gets smaller when the network grows.

--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -53,7 +53,7 @@ In addition to required header parameters as specified in RFC7515 the following 
   other algorithms SHALL NOT be used.
 
 * **cty**: MUST contain the type of the transaction content indicating how to interpret it.
-* **crit** MUST contain the **sigt**, **ver** and **prevs** headers.
+* **crit** MUST contain the **sigt**, **ver**, **prevs** and **pal** headers.
 
 The **jku**, **x5c** and **x5u** header parameters SHOULD NOT be used and MUST be ignored by when processing the transaction.
 
@@ -67,7 +67,7 @@ In addition to the registered header parameters, the following headers MUST be p
 
 The following protected headers MAY be present:
 
-* **pal**: MUST contain the encrypted address of the recipient \(used for private transactions, see section 3.8\).
+* **pal**: MUST contain the encrypted addresses of the participants \(used for private transactions, see section 3.8\).
 
 To aid performance of validating the DAG the JWS SHALL NOT contain the actual application data of the transaction. Instead, the JWS payload MUST contain the SHA-256 hash of the contents encoded as hexadecimal, lower case string, e.g.: `386b20eeae8120f1cd68c354f7114f43149f5a7448103372995302e3b379632a`
 
@@ -158,32 +158,32 @@ Since the transaction content is detached from the transaction itself and referr
 
 ### 3.8 Private Transactions
 
-Private transactions are transactions that contain sensitive content, intended for a single specific, or multiple recipients.
+Private transactions are transactions that contain sensitive content, intended for specific entities that participate in the transaction.
 Private transactions MUST be added to the DAG like non-private transactions.
-The recipients MUST be specified as array that contains the node DIDs of the recipients, encrypted separately for each recipient.
-To construct the data to be encrypted, the plaintext recipients MUST be joined by a newline (`\n`)
+The participants MUST be specified as array that contains the node DIDs of the participants, encrypted separately for each participant.
+To construct the data to be encrypted, the plaintext participants MUST be joined by a newline (`\n`)
 
-The recipient list MUST be encrypted for each recipient and the ciphertext specified as array as `pal` header in the JWS.
+The participant list MUST be encrypted for each participant and the ciphertext specified as array as `pal` header in the JWS.
 
-Given 2 recipients `did:nuts:recipient-A` and `did:nuts:recipient-B`:
+Given 2 participants `did:nuts:participant-A` and `did:nuts:participant-B`:
 
 ```
-encoded_recipients = join("did:nuts:recipient-A", "did:nuts:recipient-B", "\\n")
+encoded_participants = join("did:nuts:participant-A", "did:nuts:participant-B", "\\n")
 
 pal = []
 
-for each recipient
-  encrypted_recipients = ecies_encrypt(encoded_recipients, recipient.encryption_public_key)
-  pal = append(to, encrypted_recipients)
+for each participant
+  encrypted_participants = ecies_encrypt(encoded_participants, participant.encryption_public_key)
+  pal = append(pal, encrypted_participants)
 
 transaction.pal = pal
 ```
 
 To decrypt the header, the process above is applied in reverse. If one of the decrypted values match the local node's DID,
-it indicates the local node is (one of) the intended recipient, and it SHOULD try to retrieve the contents.
+it indicates the local node is (one of) the intended participant, and it SHOULD try to retrieve the contents.
 
-The encryption key to be used MUST be an elliptic curve of the recipient.
-In the context of DIDs, it MUST be the first `keyAgreement` key in the recipient's DID document.  
+The encryption key to be used MUST be an elliptic curve of the participant.
+In the context of DIDs, it MUST be the first `keyAgreement` key in the participant's DID document.  
 For encryption of the `pal` header the ECIES encryption algorithm MUST be used.
 
 See appendix A on the reasoning behind encrypting the `pal` header.
@@ -194,12 +194,14 @@ See appendix A on the reasoning behind encrypting the `pal` header.
 eyJhbGciOiJFUzI1NiIsImN0eSI6ImZvby9iYXIiLCJjcml0IjpbInNpZ3QiLCJ2ZXIiLCJwcmV2cyIsImp3ayJdLCJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiJUTXVzeXNWQTJJcHduNnZFMjhNWUQtOGtPZFN6ajZVTy1MeGE0ZWhLd0d3IiwieSI6IjdZbC1hb2ZPOC1qNHN6aVBYeGREdVVVSXdDSHlaeWtnTTJmdWlISEQxUzgifSwicHJldnMiOlsiMzk3MmRjOTc0NGY2NDk5ZjBmOWIyZGJmNzY2OTZmMmFlN2FkOGFmOWIyM2RkZTY2ZDZhZjg2YzlkZmIzNjk4NiIsImIzZjJjM2MzOTZkYTFhOTQ5ZDIxNGU0YzJmZTBmYzlmYjVmMmE2OGZmMTg2MGRmNGVmMTBjOTgzNWU2MmU3YzEiXSwic2lndCI6MTYwMzQ1Nzk5OSwidmVyIjoxfQ.NDUyZDllODlkNWJkNWQ5MjI1ZmI2ZGFlY2Q1NzllNzM4OGExNjZjNzY2MWNhMDRlNDdmZDNjZDg0NDZlNDYyMA.-jpKBZQ3sc0x34MwnbO8mSiGdUYCfQXNO91RMnvFRq0YZ5pmbKmRYg--zaie-N7wIJhIFbZyuOyJdlcPwZrELQ
 ```
 
-## Appendix A: Correlation Attacks on Private Transactions
+## Appendix A: Design decisions
+
+### A.1 Correlation Attacks on Private Transactions
 
 When multiple encrypted documents, intended to be anonymous, contain (encrypted or not) data that is the same for every encrypted document,
 they could be related to each other, deriving information from their context. E.g., sender, time of sending, etc.
 In the context of Nuts: a care organization might issue multiple `NutsAuthorizationCredential`s (meant for giving access to EHR records) at once, to a set of care organizations.
-If the recipients are publicly readable, this gives knowledge of the name, physical location and care type of the organizations that have access.
+If the participants are publicly readable, this gives knowledge of the name, physical location and care type of the organizations that have access.
 Given enough public knowledge and/or information from other contexts, one could ultimately pinpoint the set of issues VCs to a person (e.g. a relative or a celebrity).
 
 To mitigate this attack, given a plaintext and encryption key, every subsequent encryption operation (with the same plaintext and key) must yield a new, random ciphertext.

--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -67,7 +67,7 @@ In addition to the registered header parameters, the following headers MUST be p
 
 The following protected headers MAY be present:
 
-* **to**: MUST contain the encrypted address of the recipient \(used for private transactions, see section 3.8\).
+* **pal**: MUST contain the encrypted address of the recipient \(used for private transactions, see section 3.8\).
 
 To aid performance of validating the DAG the JWS SHALL NOT contain the actual application data of the transaction. Instead, the JWS payload MUST contain the SHA-256 hash of the contents encoded as hexadecimal, lower case string, e.g.: `386b20eeae8120f1cd68c354f7114f43149f5a7448103372995302e3b379632a`
 
@@ -182,7 +182,8 @@ transaction.pal = pal
 To decrypt the header, the process above is applied in reverse. If one of the decrypted values match the local node's DID,
 it indicates the local node is (one of) the intended recipient, and it SHOULD try to retrieve the contents.
 
-The encryption key to be used MUST be one of the elliptic curve public encryption keys (`keyAgreement` key in DID documents) of the recipient.
+The encryption key to be used MUST be an elliptic curve of the recipient.
+In the context of DIDs, it MUST be the first `keyAgreement` key in the recipient's DID document.  
 For encryption of the `pal` header the ECIES encryption algorithm MUST be used.
 
 See appendix A on the reasoning behind encrypting the `pal` header.


### PR DESCRIPTION
Specifies how private transactions are encoded.

TODO:

- [x] Write appendix A
- [x] Specify ACL (how can the creator of a TX determine the recipient later on, since it hasn't got the decryption key?)

Fixes https://github.com/nuts-foundation/nuts-specification/issues/155