### PR TITLE
RFC017: Service discovery

### DIFF
--- a/rfc/rfc017-distributed-network-grpc-v2.md
+++ b/rfc/rfc017-distributed-network-grpc-v2.md
@@ -469,6 +469,6 @@ If all nodes send at best-effort, that will be enough due to the number of nodes
 ## X. Service Discovery
 
 Although a (or multiple) trusted bootstrap node is required for initially connecting to the network, nodes SHOULD discover new peers by searching for `NutsComm` endpoints in the received DID documents.
-This SHOULD be done after the initial DAG sync is completed, to avoid connecting to non-existing endpoints resolved from older versions of DID documents.
-
-TODO: What if a node were to publish a competitor's NutsComm endpoint in its DID document, causing implementations to ignore the competitor's endpoint (because the malicious node's DID document is processed first)
+Only absolute `NutsComm` endpoints SHOULD be discovered. References to other DID documents, IP addresses, and domains as listed in [RFC2606](https://www.ietf.org/archive/id/draft-chapin-rfc2606bis-00.html) SHOULD be ignored.
+Connecting to discovered endpoints SHOULD be delayed until after the initial DAG sync is completed.
+This prevents trying to connect using outdated information, but more importantly, connecting to every endpoint as it is discovered would result in requesting the remainder of the DAG from all newly connected peers.

--- a/rfc/rfc017-distributed-network-grpc-v2.md
+++ b/rfc/rfc017-distributed-network-grpc-v2.md
@@ -465,3 +465,10 @@ If such an error occurs, the node must log the error for analysis by an operator
 A lot of the response type messages only state a node SHOULD send a response or a followup and not a MUST. This is because a node might have a reason to stop/pause processing.
 A node might be to busy doing something else, or it might be doing a migration or backup. Because nodes communicate with multiple nodes, a single busy node should not matter that much.
 If all nodes send at best-effort, that will be enough due to the number of nodes available.
+
+## X. Service Discovery
+
+Although a (or multiple) trusted bootstrap node is required for initially connecting to the network, nodes SHOULD discover new peers by searching for `NutsComm` endpoints in the received DID documents.
+This SHOULD be done after the initial DAG sync is completed, to avoid connecting to non-existing endpoints resolved from older versions of DID documents.
+
+TODO: What if a node were to publish a competitor's NutsComm endpoint in its DID document, causing implementations to ignore the competitor's endpoint (because the malicious node's DID document is processed first)


### PR DESCRIPTION
Questions to answer:

- [ ]  What if a node were to publish a competitor's `NutsComm` endpoint in its DID document, causing implementations to ignore the competitor's endpoint (because the malicious node's DID document is processed first). Maybe verify the `NutsComm` endpoint against the TLS certificate, so it can't be spoofed?
- [ ] Should we limit the number of (outbound) connections made?
- [ ] If we do, how do we prevent that all nodes connect to the first X nodes they discover, leaving other nodes undiscovered (random/nearest neighbour using hash distance).

But maybe, with the limited number of nodes we now have, we can safely let the nodes build a full mesh (or limit it to an arbitrarily chosen count, like 50)?