### PR TITLE
RFC017/RFC005/RFC008: Require at least TLS v1.2 for connections

### DIFF
--- a/rfc/rfc005-distributed-network-using-grpc.md
+++ b/rfc/rfc005-distributed-network-using-grpc.md
@@ -149,7 +149,7 @@ When connecting, the node and peer MUST exchange their protocol version as `vers
 
 ### 6.5. Security
 
-Connections MUST be secured using TLS v1.3 \(or higher\) with both client- and server X.509 certificates. Refer to [RFC008 Certificate Structure](rfc008-certificate-structure.md) for requirements regarding these certificates and which Certificate Authorities should be accepted.
+Connections MUST be secured using TLS v1.2 \(or higher\) with both client- and server X.509 certificates. Refer to [RFC008 Certificate Structure](rfc008-certificate-structure.md) for requirements regarding these certificates and which Certificate Authorities should be accepted.
 
 ## 7. Protobuf Definition
 

--- a/rfc/rfc008-certificate-structure.md
+++ b/rfc/rfc008-certificate-structure.md
@@ -74,3 +74,8 @@ In case of theft or loss of a private key and/or certificate, please consult the
 
 All connections mentioned in §3 MUST be accepted. A node operator MAY NOT deny a connection request other than those using a banned or revoked certificate. A governance framework SHOULD be in place to determine how a certificate can be banned. Banning a certificate does not replace the revoking mechanism of a CA.
 
+## 7. TLS Protocols
+
+Connections must be secured according to the guidelines provided by the Dutch National Cyber Security Center (NCSC).
+The current version of this guideline is [2.1](https://www.ncsc.nl/documenten/publicaties/2021/januari/19/ict-beveiligingsrichtlijnen-voor-transport-layer-security-2.1).
+According to the guideline, we require at least TLS v1.2 and advice strongly to support TLS v1.3 as well.

--- a/rfc/rfc017-distributed-network-grpc-v2.md
+++ b/rfc/rfc017-distributed-network-grpc-v2.md
@@ -28,6 +28,7 @@ This document is released under the [Attribution-ShareAlike 4.0 International \(
 
 Please see the [protobuf definition](https://raw.githubusercontent.com/nuts-foundation/nuts-node/master/network/transport/v2/protocol.proto)
 for the messages that are referred to in this RFC.
+Connections are subject to the requirements specified by [RFC008 Certificate Structure](rfc/rfc008-certificate-structure.md).
 
 ## 2. Terminology
  


### PR DESCRIPTION
Effectively downgrade the requirement from v1.3 to v1.2. We follow the NCSC for TLS guidelines which currently (https://www.ncsc.nl/documenten/publicaties/2021/januari/19/ict-beveiligingsrichtlijnen-voor-transport-layer-security-2.1) assesses TLS v1.2 as "voldoende".

This change is incepted through requests from the community to support TLS stacks that don't support v1.3 yet.