### PR TITLE
repudiation bit clarify in RFC002

### DIFF
--- a/rfc/rfc002-authentication-token.md
+++ b/rfc/rfc002-authentication-token.md
@@ -351,7 +351,7 @@ In order to validate an UZI signed JWS, the validator MUST perform the following
 * The `alg` value MUST be equal to `RS256`
 * The `signature` MUST be correct and created with the certificate from the `x5c` header field
 * The certificate MUST descend from the known CA tree
-* The certificate MUST have the `repudiation` bit set
+* The certificate MUST have the `nonRepudiation`, a.k.a. `contentCommitment`, bit set to 1.
 * The certificate MUST NOT be revoked
 * If the `typ` is a JWT and the JSON payload contains an `iat`, the certificate chain MUST be valid at the given date
 


### PR DESCRIPTION
* non-repudiation mistaken for repudiation
* mention newer `contentCommitment` name
* flags are set; bits are 0 or 1