### PR TITLE
RFC004 clarify lc + lc drops

### DIFF
--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -75,6 +75,9 @@ The following protected headers MAY be present:
 
 * **pal**: MUST contain the encrypted addresses of the participants \(used for private transactions, see section 3.8\).
 
+When adding a new transaction, that transaction MUST point (through the **prevs** field) to the transaction with the highest **lc** value.
+If multiple transactions have the highest **lc** value, a single one of them SHOULD be used.
+
 To aid performance of validating the DAG the JWS SHALL NOT contain the actual application data of the transaction. Instead, the JWS payload MUST contain the SHA-256 hash of the contents encoded as hexadecimal, lower case string, e.g.: `386b20eeae8120f1cd68c354f7114f43149f5a7448103372995302e3b379632a`
 
 The contents then MAY be stored next to or apart from the transaction itself \(but that's out of scope for this RFC\).

--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -67,9 +67,9 @@ In addition to the registered header parameters, the following headers MUST be p
   * The root transaction SHALL NOT have any **prevs** entries.
   * Non-root transactions MUST include one reference as described in subsection 3.2.1.
   * If a **kid** parameter is present, then **prevs** MUST also contain a reference to a transaction which its content includes the key entry with the respective **kid**.
-* **lc**: MUST be a positive number constructed as follows:
-  * if the transaction has no entries in **prevs**, it's' lc value is **0**.
-  * otherwise, the value MUST be equal to `max(prev1, ... prevN)+1`.
+* **lc**: (Lamport's Logical Clock) MUST be a natural number.
+  * If the transaction has **prevs** entries, then **lc** is 0.
+  * Otherwise, **lc** MUST be the highest **prevs** entry plus 1.
 
 The following protected headers MAY be present:
 

--- a/rfc/rfc004-verifiable-transactional-graph.md
+++ b/rfc/rfc004-verifiable-transactional-graph.md
@@ -68,7 +68,7 @@ In addition to the registered header parameters, the following headers MUST be p
   * Non-root transactions MUST include one reference as described in subsection 3.2.1.
   * If a **kid** parameter is present, then **prevs** MUST also contain a reference to a transaction which its content includes the key entry with the respective **kid**.
 * **lc**: (Lamport's Logical Clock) MUST be a natural number.
-  * If the transaction has **prevs** entries, then **lc** is 0.
+  * If the transaction has no **prevs** entries, then **lc** is 0.
   * Otherwise, **lc** MUST be the highest **prevs** entry plus 1.
 
 The following protected headers MAY be present:


### PR DESCRIPTION
Mention that the `lc` property stand for Lamport's Clock.
Clarify what "only use one" means and implies.