### PR TITLE
RFC017: Readability and minor corrections

### DIFF
--- a/rfc/rfc017-distributed-network-grpc-v2.md
+++ b/rfc/rfc017-distributed-network-grpc-v2.md
@@ -265,7 +265,7 @@ The protocol operates by comparing transaction pages, starting at the last page 
 3. When receiving the message, Bob subtracts Alice's IBLT from his own IBLT for the given range (§6.2.3) and does one of the following:
    * If not decodable, go to step 1 and send State message for the previous page.
      * If already comparing the first page, request all transactions of the first page.
-   * If decodable, send a request for missing transactions if there are any.
+   * If decodable and missing transactions, send a request for missing transactions
    * If Alice's highest Lamport Clock value is higher than the LC value sent in 1, then request transactions over a range of Lamport Clock values (§6.2.4)
 
 4. When receiving a request for transactions, Alice responds with a message including the requested transactions.

--- a/rfc/rfc017-distributed-network-grpc-v2.md
+++ b/rfc/rfc017-distributed-network-grpc-v2.md
@@ -256,7 +256,7 @@ The protocol generally operates as follows:
     * Highest Lamport Clock value over all transactions (LC).
     
 2. When receiving Bob's message, Alice compares the XOR value from Bob with its own (§6.2.2):
-    * When the XOR is the same and the LC value equals Alice's highest Lamport Clock value: no action required.
+    * When the XOR is the same: no action required.
     * When different, send a message containing:
       * LC value sent by Bob
       * the IBLT that includes the Lamport Clock range of 0-LC(Bob)

--- a/rfc/rfc017-distributed-network-grpc-v2.md
+++ b/rfc/rfc017-distributed-network-grpc-v2.md
@@ -249,7 +249,7 @@ Conversion of integers to bytes MUST be in little-endian format.
 All messages and values mentioned in this chapter are scoped to a single connection between two nodes.
 *Alice* and *Bob* are used to represent two nodes connected to each other.
 
-The protocol generally operates as follows:
+The protocol operates by comparing transaction pages, starting at the last page and working back when pages differ.
 
 1. Bob sends a State message in response to a gossip message when conditions require so (§6.2.1):
     * XOR of all known transaction references.
@@ -263,7 +263,8 @@ The protocol generally operates as follows:
       * Alice's highest Lamport Clock value
 
 3. When receiving the message, Bob subtracts Alice's IBLT from his own IBLT for the given range (§6.2.3) and does one of the following:
-   * If not decodable, go to 1 and send values based on the previous page, or request all transactions on lowest page if already comparing the lowest page.
+   * If not decodable, go to step 1 and send State message for the previous page.
+     * If already comparing the first page, request all transactions of the first page.
    * If decodable, send a request for missing transactions if there are any.
    * If Alice's highest Lamport Clock value is higher than the LC value sent in 1, then request transactions over a range of Lamport Clock values (§6.2.4)
 

--- a/rfc/rfc017-distributed-network-grpc-v2.md
+++ b/rfc/rfc017-distributed-network-grpc-v2.md
@@ -251,25 +251,25 @@ All messages and values mentioned in this chapter are scoped to a single connect
 
 The protocol generally operates as follows:
 
-1. Alice sends a State message in response to a gossip message when conditions require so (§6.2.1):
+1. Bob sends a State message in response to a gossip message when conditions require so (§6.2.1):
     * XOR of all known transaction references.
     * Highest Lamport Clock value over all transactions (LC).
     
-2. When receiving Alice's message, Bob compares the XOR value from Alice with its own (§6.2.2):
-    * When the XOR is the same and the LC value equals BOB's highest Lamport Clock value: no action required.
+2. When receiving Bob's message, Alice compares the XOR value from Bob with its own (§6.2.2):
+    * When the XOR is the same and the LC value equals Alice's highest Lamport Clock value: no action required.
     * When different, send a message containing:
-      * LC value sent by Alice
-      * the IBLT that includes the Lamport Clock range of 0-LC(Alice)
-      * Bob's highest Lamport Clock value
+      * LC value sent by Bob
+      * the IBLT that includes the Lamport Clock range of 0-LC(Bob)
+      * Alice's highest Lamport Clock value
 
-3. When receiving the message, Alice subtracts Bob's IBLT from her own IBLT for the given range (§6.2.3) and does one of the following:
+3. When receiving the message, Bob subtracts Alice's IBLT from his own IBLT for the given range (§6.2.3) and does one of the following:
    * If not decodable, go to 1 and send values based on the previous page, or request all transactions on lowest page if already comparing the lowest page.
    * If decodable, send a request for missing transactions if there are any.
-   * If Bob's highest Lamport Clock value is higher than the LC value sent in 1, then request transactions over a range of Lamport Clock values (§6.2.4)
+   * If Alice's highest Lamport Clock value is higher than the LC value sent in 1, then request transactions over a range of Lamport Clock values (§6.2.4)
 
-4. When receiving a request for transactions, Bob responds with a message including the requested transactions.
+4. When receiving a request for transactions, Alice responds with a message including the requested transactions.
 
-5. After adding Bob's transactions to the DAG (making sure its cryptographic signature is valid), query the payload if it's missing.
+5. After adding Alice's transactions to the DAG (making sure its cryptographic signature is valid), query the payload if it's missing.
 
 A node MUST make sure to only add transactions of which all previous transactions are present.
 


### PR DESCRIPTION
- In chapter 5 (gossip), Alice gossips to Bob, which responds by starting set reconciliation. For readability, chapter 6 should keep using these roles to avoid confusion.
- 6.2: only compare XOR when receiving State message (according to implementation)