### PR TITLE
RFC008: backport trust chain updates to v1

### DIFF
--- a/rfc/rfc008-certificate-structure.md
+++ b/rfc/rfc008-certificate-structure.md
@@ -45,10 +45,21 @@ Other terminology is taken from the [Nuts Start Architecture](rfc001-nuts-start-
 The PKIoverheid CA tree is the choice of CA to trust for production use. It's widely trusted and supported. There are multiple vendors that can issue a certificate. A PKIo TLS certificate MUST be used to secure inter-node connections as well as the peer-to-peer connections used to exchange data. Production nodes SHOULD not accept any other certificate than a PKIoverheid certificate. The certificate SHOULD be used as both server as client certificate in a mutual TLS connection.
 
 ### 3.1 Certificate Authority trust chain
+A node will need to configure the correct CA-tree so other nodes can connect. 
+All certificates that are part of the `Domein Private Services` trust chain as identified by intermediate certificate `Staat der Nederlanden Private Services CA – G1` should be configured.
+The certificates in this chain may change over time, and can be viewed and downloaded from the [PKIoverheid](https://cert.pkioverheid.nl/cert-pkioverheid-nl.htm) website.
 
-A node will need to configure the correct CA-tree so other nodes can connect. The certificate to configure are the **Staat der Nederlanden Private Root CA G1** root certificate and the **Staat der Nederlanden Private Services CA – G1** CA. All certificates can be downloaded from the [PKIoverheid](https://cert.pkioverheid.nl/cert-pkioverheid-nl.htm) website.
+At the time of writing the chain consists of the following certificates:
+- **Staat der Nederlanden Private Root CA G1** (root certificate)
+  - **Staat der Nederlanden Private Services CA – G1**
+    - **KPN PKIoverheid Private Services CA - G1**
+    - **QuoVadis PKIoverheid Private Services CA - G1** 
+    - **DigiCert QuoVadis PKIoverheid Private Services CA - 2023**
+    - **UZI-register Private Server CA G1**
+    - **ZOVAR Private Server CA G1**
+    - **Digidentity BV PKIoverheid Private Services CA - G1**
 
-TSPs are responsible for signing certificates. The TSPs have their own CA. To trust all PKIo certificates, any software that validates a certificate and its chain, MUST trust any intermediate CA below the **Staat der Nederlanden Private Services CA – G1** CA.
+Do not include other PKIoverheid CA certificates.
 
 The PKIoverheid private services CA is not by default accepted by browsers and operating systems.
 


### PR DESCRIPTION
apparently there were already some changes on v1, but not on the main branch. Including the actual list of certificates can be used as confirmation by implementers, so I think the change still has value.


back port of #272 